### PR TITLE
fix identfail. error

### DIFF
--- a/broker/feedbroker.py
+++ b/broker/feedbroker.py
@@ -173,6 +173,8 @@ class FeedConn(EventGen):
 					rest = buffer(data, 0)
 					ident, hash = rest[1:1+ord(rest[0])], rest[1+ord(rest[0]):]
 					self.auth(ident, hash)
+					if self.delay:
+						return
 
 		except BadClient:
 			self.conn.close()


### PR DESCRIPTION
If the auth and other type messages are send in a TCP packet, feedbroker.py io_in will process other message before checkauth run, and the client will see a identfail. error. 
