### PR TITLE
Make sure subscriptions are sent after reconnects

### DIFF
--- a/lib/hpfeeds.py
+++ b/lib/hpfeeds.py
@@ -163,6 +163,7 @@ class HPC(object):
 
 	def run(self, message_callback, error_callback):
 		while not self.stopped:
+			self._subscribe()
 			while self.connected:
 				try:
 					d = self.recv()
@@ -215,7 +216,11 @@ class HPC(object):
 			chaninfo = [chaninfo,]
 		for c in chaninfo:
 			self.subscriptions.add(c)
+
+	def _subscribe(self):
+		for c in self.subscriptions:
 			try:
+				logger.debug('Sending subscription for {0}.'.format(c))
 				self.send(msgsubscribe(self.ident, c))
 			except Disconnect:
 				self.connected = False


### PR DESCRIPTION
Fixes a bug where a hpfeed client would stop receiving data after a
reconnect.

To reproduce start the client:

``` shell
hpfeeds-client -i XXXXXXX -s YYYYYYYYY --host hpfriends.honeycloud.net -p 20000 -c dionaea.capture subscribe
```

Afterwards somehow kill the connection:

``` shell
tcpkill -i eth0 host hpfriends.honeycloud.net
CTRL-C
```

After those steps the client will reconnect but not resend subscriptions.
