### PR TITLE
Add Database support to Brokers

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -12,5 +12,6 @@ if sys.version_info[0] == 2:
         "tests/test_twisted_service.py",
         "tests/test_broker_auth_env.py",
         "tests/test_broker_auth_sqlite.py",
+        "tests/test_broker_auth_databases.py",
     ])
 

--- a/dev.txt
+++ b/dev.txt
@@ -20,4 +20,4 @@ urllib3==1.22
 Automat==0.8.0
 Twisted==18.4.0
 
-databases[sqlite] python_version > '3.5'
+databases[sqlite]; python_version > '3.5'

--- a/dev.txt
+++ b/dev.txt
@@ -20,4 +20,4 @@ urllib3==1.22
 Automat==0.8.0
 Twisted==18.4.0
 
-databases[sqlite]
+databases[sqlite] python_version > '3.5'

--- a/dev.txt
+++ b/dev.txt
@@ -19,3 +19,5 @@ urllib3==1.22
 
 Automat==0.8.0
 Twisted==18.4.0
+
+databases[sqlite]

--- a/docs/broker.rst
+++ b/docs/broker.rst
@@ -98,8 +98,10 @@ Supported Database drivers are:
   - postrgesql
   - mysql
   - mysql compatable e.g. mariadb, aurora
+  - sqlite
 
-You may need to install the specific database driver for your selected database, more information can be found at https://pypi.org/project/databases/
+You may need to install the specific database driver for your selected database, more information can be 
+found at https://pypi.org/project/databases/
 
 .. code-block: bash
 
@@ -108,7 +110,7 @@ You may need to install the specific database driver for your selected database,
   $ pip install databases[sqlite]
 
 Using SQLite with this auth mechanism requires JSON support that can be found in SQLite version > 3.3 and Python3
-Previsous versions of SQLite may be supported with the JSON1 SQLite extension.
+Previous versions of SQLite may be supported with the JSON1 SQLite extension.
 
 Any authentication can be included within the connection string
 For example:

--- a/docs/broker.rst
+++ b/docs/broker.rst
@@ -91,6 +91,10 @@ restart.
 Database authentication store
 --------------------------
 
+Please note that this authentication provider is only supported when running with `Python >= 3.5`
+If you need to use an SQLite auth provider and you are not able to install the database dependancies as listed below
+you will need to use the default SQLite provider. 
+
 When starting the broker you can pass a database connection string. Auth requests are then checked against
 the selected Database in a table named auth_keys. 
 
@@ -109,7 +113,6 @@ found at https://pypi.org/project/databases/
   $ pip install databases[mysql]
   $ pip install databases[sqlite]
 
-The broker provides a default SQLite authentication store that requires no additional dependancies.
 
 Using SQLite with this auth mechanism requires JSON support that can be found in SQLite version > 3.3 and Python3
 Previous versions of SQLite may be supported with the JSON1 SQLite extension. 

--- a/docs/broker.rst
+++ b/docs/broker.rst
@@ -88,6 +88,71 @@ its secret type updates to the secret object in the Kubernetes API will be autom
 a Pod's filesystem. Hpfeeds will spot those updates and process them immediately without needing a
 restart.
 
+Database authentication store
+--------------------------
+
+When starting the broker you can pass a database connection string. Auth requests are then checked against
+the selected Database in a table named auth_keys. 
+
+Supported Database drivers are:
+  - postrgesql
+  - mysql
+  - mysql compatable e.g. mariadb, aurora
+
+You may need to install the specific database driver for your selected database, more information can be found at https://pypi.org/project/databases/
+
+.. code-block: bash
+
+  $ pip install databases[postgresql]
+  $ pip install databases[mysql]
+  $ pip install databases[sqlite]
+
+Using SQLite with this auth mechanism requires JSON support that can be found in SQLite version > 3.3 and Python3
+Previsous versions of SQLite may be supported with the JSON1 SQLite extension.
+
+Any authentication can be included within the connection string
+For example:
+
+.. code-block:: bash
+
+    hpfeeds-broker -e tcp:port=20000 --exporter=0.0.0.0:9431 --auth="database+mysql://honeyswarm:honeyswarm@127.0.0.1/honeyswarm"
+
+
+.. code-block:: bash
+
+    hpfeeds-broker -e tcp:port=20000 --exporter=0.0.0.0:9431 --auth="database+postgresql://localhost/example"
+
+.. code-block:: bash
+
+    hpfeeds-broker -e tcp:port=20000 --exporter=0.0.0.0:9431 --auth="database+sqlite:///auth_keys.db"
+
+To add a new user
+
+.. code-block:: bash
+
+    mysql -u admin -p <password>
+    use database_name;
+    
+    mysql> INSERT INTO auth_keys (identifier, secret, publish, subscribe) VALUES ('testing', 'secretkey', '["channel1", "channel2"]', '["channel2"]');
+    Query OK, 1 row affected (0.00 sec)
+
+
+To Find all users
+
+.. code-block:: bash
+
+    mysql -u admin -p <password>
+    use database_name;
+
+    mysql> select * from auth_keys;
+    +----+------------+-----------+--------------------------+--------------+
+    | id | identifier | secret    | publish                  | subscribe    |
+    +----+------------+-----------+--------------------------+--------------+
+    |  1 | testing    | secretkey | ["channel1", "channel2"] | ["channel2"] |
+    +----+------------+-----------+--------------------------+--------------+
+    1 row in set (0.00 sec)
+
+
 
 SQLite authentication store
 ---------------------------

--- a/docs/broker.rst
+++ b/docs/broker.rst
@@ -109,15 +109,18 @@ found at https://pypi.org/project/databases/
   $ pip install databases[mysql]
   $ pip install databases[sqlite]
 
+The broker provides a default SQLite authentication store that requires no additional dependancies.
+
 Using SQLite with this auth mechanism requires JSON support that can be found in SQLite version > 3.3 and Python3
-Previous versions of SQLite may be supported with the JSON1 SQLite extension.
+Previous versions of SQLite may be supported with the JSON1 SQLite extension. 
+
 
 Any authentication can be included within the connection string
 For example:
 
 .. code-block:: bash
 
-    hpfeeds-broker -e tcp:port=20000 --exporter=0.0.0.0:9431 --auth="database+mysql://honeyswarm:honeyswarm@127.0.0.1/honeyswarm"
+    hpfeeds-broker -e tcp:port=20000 --exporter=0.0.0.0:9431 --auth="database+mysql://username:password@127.0.0.1/example"
 
 
 .. code-block:: bash
@@ -127,6 +130,34 @@ For example:
 .. code-block:: bash
 
     hpfeeds-broker -e tcp:port=20000 --exporter=0.0.0.0:9431 --auth="database+sqlite:///auth_keys.db"
+
+To create the tables under mysql or sqlite
+
+.. code-block:: sql
+
+    CREATE TABLE `auth_keys` (
+      `id` int AUTO_INCREMENT NOT NULL ,
+      `identifier` varchar(36) DEFAULT NULL,
+      `secret` varchar(36) DEFAULT NULL,
+      `publish` json DEFAULT NULL,
+      `subscribe` json DEFAULT NULL,
+      PRIMARY KEY (`id`)
+    )
+
+To create the tables for a PostgreSQL Database
+
+.. code-block:: sql
+
+    CREATE SEQUENCE auth_keys_seq;
+
+    CREATE TABLE auth_keys (
+      id int NOT NULL DEFAULT NEXTVAL ('auth_keys_seq'),
+      identifier varchar(36) DEFAULT NULL,
+      secret varchar(36) DEFAULT NULL,
+      publish json DEFAULT NULL,
+      subscribe json DEFAULT NULL,
+      PRIMARY KEY (id)
+    )
 
 To add a new user
 

--- a/hpfeeds/broker/auth/database.py
+++ b/hpfeeds/broker/auth/database.py
@@ -14,7 +14,7 @@ class Authenticator(object):
 
     def __init__(self, connection_string):
         self.logger = logging.getLogger('hpfeeds.broker.auth.databases.Authenticator')
-        self.connection_string = connection_string.lstrip("database+")
+        self.connection_string = connection_string.replace("database+", "")
         self.database = Database(self.connection_string)
 
         if not lib_databases:

--- a/hpfeeds/broker/auth/database.py
+++ b/hpfeeds/broker/auth/database.py
@@ -1,0 +1,65 @@
+import json
+import logging
+
+
+from hpfeeds.broker.server import ServerException
+
+try:
+    from databases import Database
+    lib_databases = True
+except ImportError:
+    lib_databases = False
+
+
+
+
+class Authenticator(object):
+
+    def __init__(self, connection_string):
+        self.logger = logging.getLogger('hpfeeds.broker.auth.databases.Authenticator')
+        self.connection_string = connection_string.lstrip("database+")
+        self.connected = False
+
+        if not lib_databases:
+            raise ServerException("The module 'databases.Database' is not available - is the databases package installed?")
+    
+    async def db_connect(self):
+
+        try:
+            self.logger.debug("Connecting to database")
+            self.database = Database(self.connection_string)
+            await self.database.connect()
+            self.connected = True
+        except Exception as err:
+            raise ServerException(f"Unable to connect to database: {err}")
+
+    async def start(self):
+        pass
+
+    async def close(self):
+        await self.database.disconnect()
+
+    async def get_authkey(self, ident):
+        self.logger.debug(f"Auth key for {ident} requested")
+
+        if not self.connected:
+            await self.db_connect()
+
+        query = "SELECT * from auth_keys WHERE identifier = :ident LIMIT 1"
+        result = await self.database.fetch_one(query=query, values={"ident": ident})
+
+        if not result:
+            return None
+
+        try:
+            auth_key = dict(
+                owner=result[1],
+                secret=result[2],
+                ident=result[1],
+                pubchans=json.loads(result[3]),
+                subchans=json.loads(result[4]),
+            )
+        except Exception as err:
+            raise ServerException(f"Unable to parse auth row from database query: {err}")
+
+        return auth_key

--- a/hpfeeds/broker/auth/database.py
+++ b/hpfeeds/broker/auth/database.py
@@ -1,7 +1,6 @@
 import json
 import logging
 
-
 from hpfeeds.broker.server import ServerException
 
 try:
@@ -9,8 +8,6 @@ try:
     lib_databases = True
 except ImportError:
     lib_databases = False
-
-
 
 
 class Authenticator(object):
@@ -22,7 +19,7 @@ class Authenticator(object):
 
         if not lib_databases:
             raise ServerException("The module 'databases.Database' is not available - is the databases package installed?")
-    
+
     async def db_connect(self):
 
         try:

--- a/hpfeeds/scripts/broker.py
+++ b/hpfeeds/scripts/broker.py
@@ -4,7 +4,7 @@ import sys
 
 import aiorun
 
-from hpfeeds.broker.auth import env, json, mongo, multi, sqlite
+from hpfeeds.broker.auth import database, env, json, mongo, multi, sqlite
 from hpfeeds.broker.server import Server, ServerException
 
 
@@ -15,6 +15,8 @@ def get_authenticator(auth):
         return env.Authenticator()
     elif auth.startswith("mongo"):
         return mongo.Authenticator(auth)
+    elif auth.startswith("database+"):
+        return database.Authenticator(auth)
     return sqlite.Authenticator('sqlite.db')
 
 

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,9 @@ setup(
         ],
         'broker-auth-mongo': [
             'motor',
+        ],
+        'broker-auth-database': [
+            'databases',
         ]
     },
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,6 @@
 import logging
-import sys
 
 import pytest
-
-collect_ignore = []
-if sys.version_info[0] == 2:
-    collect_ignore.extend([
-        "tests/test_broker_auth_databases.py",
-    ])
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,13 @@
 import logging
+import sys
 
 import pytest
+
+collect_ignore = []
+if sys.version_info[0] == 2:
+    collect_ignore.extend([
+        "tests/test_broker_auth_databases.py",
+    ])
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_broker_auth_databases.py
+++ b/tests/test_broker_auth_databases.py
@@ -1,5 +1,5 @@
-import os
 import asyncio
+import os
 import unittest
 
 from hpfeeds.broker.auth.database import Authenticator
@@ -46,7 +46,9 @@ class TestAuthenticator(unittest.TestCase):
             await a.database.execute(query=create_query)
 
             # Add a user
-            write_query = """INSERT INTO auth_keys (id, identifier, secret, publish, subscribe) VALUES (1, 'aaa', 'bbb', '["a", "b", "c"]', '["d", "e", "f"]')"""
+            write_query = """INSERT INTO auth_keys (id, identifier, secret, publish, subscribe)
+                             VALUES (1, 'aaa', 'bbb', '["a", "b", "c"]', '["d", "e", "f"]')"""
+
             await a.database.execute(query=write_query)
 
         # Fetch a row

--- a/tests/test_broker_auth_databases.py
+++ b/tests/test_broker_auth_databases.py
@@ -1,0 +1,59 @@
+import os
+import asyncio
+import unittest
+
+from hpfeeds.broker.auth.database import Authenticator
+
+
+def async_test(coro):
+    """" Helper to manage await calls in unittests """
+    def wrapper(*args, **kwargs):
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(coro(*args, **kwargs))
+        finally:
+            loop.close()
+    return wrapper
+
+
+class TestAuthenticator(unittest.TestCase):
+    def setup(self):
+        self.loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(None)
+
+    @async_test
+    async def test_database_sqlite(self):
+
+        a = Authenticator("database+sqlite:////tmp/test.db")
+
+        # Connect to the database
+        await a.database.connect()
+
+        # Create the table if the testdb doesnt already exist
+
+        if not os.path.exists("/tmp/test.db"):
+
+            create_query = """
+                CREATE TABLE `auth_keys` (
+                    `id` int AUTO_INCREMENT NOT NULL ,
+                    `identifier` varchar(36) DEFAULT NULL,
+                    `secret` varchar(36) DEFAULT NULL,
+                    `publish` json DEFAULT NULL,
+                    `subscribe` json DEFAULT NULL,
+                    PRIMARY KEY (`id`)
+                    )"""
+
+            await a.database.execute(query=create_query)
+
+            # Add a user
+            write_query = """INSERT INTO auth_keys (id, identifier, secret, publish, subscribe) VALUES (1, 'aaa', 'bbb', '["a", "b", "c"]', '["d", "e", "f"]')"""
+            await a.database.execute(query=write_query)
+
+        # Fetch a row
+        key = await a.get_authkey("aaa")
+
+        # Validate the results
+        assert key["owner"] == 'aaa'
+        assert key["secret"] == 'bbb'
+        assert key['pubchans'] == ['a', 'b', 'c']
+        assert key['subchans'] == ['d', 'e', 'f']


### PR DESCRIPTION
This adds multiple database support to HPFeeds using the async wrapper https://www.encode.io/databases/

It supports:

- mysql
- postgresql
- sqlite

This could in theory also replace the default sqlite auth module but that would need more thought on dependencies and ensure backwards compatibility. 

Some basic documentation has also been included 

